### PR TITLE
Config protractor and cucumberjs for acceptance tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -414,7 +414,19 @@ module.exports = function (grunt) {
         configFile: 'test/karma.conf.js',
         singleRun: true
       }
-    }
+    },
+
+    protractor: {
+      options: {
+        configFile: 'test/protractor.conf.js', // Default config file
+        keepAlive: true, // If false, the grunt process stops when the test fails.
+        noColor: false, // If true, protractor will not use colors in its output.
+        args: {
+          // Arguments passed to the command
+        }
+      },
+      run: {}
+    },
   });
 
 
@@ -445,7 +457,8 @@ module.exports = function (grunt) {
     'concurrent:test',
     'autoprefixer',
     'connect:test',
-    'karma'
+    'karma',
+    'protractor:run'
   ]);
 
   grunt.registerTask('build', [

--- a/app/index.html
+++ b/app/index.html
@@ -20,7 +20,7 @@
     <![endif]-->
 
     <!-- Add your site or application content here -->
-    <header class="centered-navigation" role="banner">
+    <header id="navbar" class="centered-navigation" role="banner">
       <div class="centered-navigation-wrapper">
         <a href="javascript:void(0)" class="mobile-logo">
           <img src="https://raw.githubusercontent.com/thoughtbot/refills/master/source/images/placeholder_logo_3_dark.png" alt="Logo image">

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "dependencies": {},
   "repository": {},
   "devDependencies": {
+    "chai": "^2.3.0",
+    "chai-as-promised": "^5.0.0",
+    "cucumber": "^0.4.9",
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^2.0.0",
     "grunt-concurrent": "^1.0.0",
@@ -25,6 +28,7 @@
     "grunt-karma-coveralls": "^2.5.3",
     "grunt-newer": "^1.1.0",
     "grunt-ng-annotate": "^0.9.2",
+    "grunt-protractor-runner": "^2.0.0",
     "grunt-svgmin": "^2.0.0",
     "grunt-usemin": "^3.0.0",
     "grunt-wiredep": "^2.0.0",
@@ -40,6 +44,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "grunt test && grunt coveralls"
+    "test": "grunt test && grunt coveralls",
+    "install": "node node_modules/grunt-protractor-runner/node_modules/protractor/bin/webdriver-manager update"
   }
 }

--- a/test/e2e/features/homepage.feature
+++ b/test/e2e/features/homepage.feature
@@ -1,0 +1,8 @@
+Feature: Homepage
+  As a customer
+  I want to visit the homepage
+  So that I can access the various features on offer
+
+  Scenario: Visit Homepage
+    Given I am on the homepage
+    Then I should see a navbar

--- a/test/e2e/features/step_definitions/basic_steps.js
+++ b/test/e2e/features/step_definitions/basic_steps.js
@@ -1,0 +1,27 @@
+'use strict';
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+var expect = chai.expect;
+var assert = require('assert');
+
+module.exports = function() {
+  this.World = require('../support/world').World;
+
+  this.Given(/^I am on the homepage$/, function (callback) {
+    browser.get('#/');
+    callback();
+  });
+
+  this.Then(/^I should see a navbar$/, function (callback) {
+    var navbar = element(by.id('navbar'));
+
+    // navbar.isElementPresent().then(function(v) {
+    //   expect(v).to.be.true;
+    // });
+    // expect(navbar.isElementPresent().then).to.be.true;
+    // assert.equal(element(by.css('#navbar')).isPresent(), true);
+    callback.pending();
+  });
+};

--- a/test/e2e/features/step_definitions/basic_steps.js
+++ b/test/e2e/features/step_definitions/basic_steps.js
@@ -4,7 +4,6 @@ var chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 
 var expect = chai.expect;
-var assert = require('assert');
 
 module.exports = function() {
   this.World = require('../support/world').World;
@@ -16,12 +15,7 @@ module.exports = function() {
 
   this.Then(/^I should see a navbar$/, function (callback) {
     var navbar = element(by.id('navbar'));
-
-    // navbar.isElementPresent().then(function(v) {
-    //   expect(v).to.be.true;
-    // });
-    // expect(navbar.isElementPresent().then).to.be.true;
-    // assert.equal(element(by.css('#navbar')).isPresent(), true);
-    callback.pending();
+    expect(navbar.isPresent()).to.eventually.equal(true).and.notify(callback);
+    callback();
   });
 };

--- a/test/e2e/features/support/world.js
+++ b/test/e2e/features/support/world.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var World = function World(callback) {
+  callback();
+};
+//
+// module.exports = function() {
+//   this.World = function World(callback) {
+//     this.prop = 'Hello from the World!'; // this property will be available in step definitions
+//
+//     this.greetings = function(name, callback) {
+//       console.log('\n----Hello ' + name);
+//       callback();
+//     };
+//
+//     callback(); // tell Cucumber we're finished and to use 'this' as the world instance
+//   };
+// };
+
+module.exports.World = World;

--- a/test/e2e/features/support/world.js
+++ b/test/e2e/features/support/world.js
@@ -3,18 +3,5 @@
 var World = function World(callback) {
   callback();
 };
-//
-// module.exports = function() {
-//   this.World = function World(callback) {
-//     this.prop = 'Hello from the World!'; // this property will be available in step definitions
-//
-//     this.greetings = function(name, callback) {
-//       console.log('\n----Hello ' + name);
-//       callback();
-//     };
-//
-//     callback(); // tell Cucumber we're finished and to use 'this' as the world instance
-//   };
-// };
 
 module.exports.World = World;

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -1,0 +1,23 @@
+// An example configuration file.
+exports.config = {
+  // directConnect: true,
+  framework: 'cucumber',
+
+  // Capabilities to be passed to the webdriver instance.
+  capabilities: {
+    'browserName': 'phantomjs'
+  },
+
+  // Spec patterns are relative to the current working directly when
+  // protractor is called.
+  specs: [
+    'e2e/features/*.feature'
+  ],
+
+  baseUrl: 'http://localhost:9000',
+
+  cucumberOpts: {
+    require: 'test/e2e/features/step_definitions/*_steps.js',
+    format: 'pretty'
+  }
+};

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -15,6 +15,7 @@ exports.config = {
   ],
 
   baseUrl: 'http://localhost:9000',
+  getPageTimeout: 30000,
 
   cucumberOpts: {
     require: 'test/e2e/features/step_definitions/*_steps.js',


### PR DESCRIPTION
@yggie @razorcd @achock 

I manage to config e2e testing using cucumberjs+protractor. But I can't get the second step to pass so if anyone would have a look also see if we can get this working :)

a run of `npm install` should install all dependencies and setup the webdriver

To run both unit+e2e tests `grunt test`

`grunt protractor:run` will execute only e2e
